### PR TITLE
Make OS X package 2x smaller

### DIFF
--- a/script/zip.js
+++ b/script/zip.js
@@ -3,8 +3,8 @@
 require('shelljs/global');
 const version = require('./version').version;
 
-exec(`cd packages/v${version} && zip -r Nocturn-darwin-x64.zip Nocturn-darwin-x64`)
-exec(`cd packages/v${version} && zip -r Nocturn-linux-x64.zip Nocturn-linux-x64`)
-exec(`cd packages/v${version} && zip -r Nocturn-win32-x64.zip Nocturn-win32-x64`)
-exec(`cd packages/v${version} && zip -r Nocturn-linux-ia32.zip Nocturn-linux-ia32`)
-exec(`cd packages/v${version} && zip -r Nocturn-win32-ia32.zip Nocturn-win32-ia32`)
+exec(`cd packages/v${version} && zip -r --symlinks Nocturn-darwin-x64.zip Nocturn-darwin-x64`)
+exec(`cd packages/v${version} && zip -r --symlinks Nocturn-linux-x64.zip Nocturn-linux-x64`)
+exec(`cd packages/v${version} && zip -r --symlinks Nocturn-win32-x64.zip Nocturn-win32-x64`)
+exec(`cd packages/v${version} && zip -r --symlinks Nocturn-linux-ia32.zip Nocturn-linux-ia32`)
+exec(`cd packages/v${version} && zip -r --symlinks Nocturn-win32-ia32.zip Nocturn-win32-ia32`)


### PR DESCRIPTION
I found that OS X package had lost its symbolic links.

So I added `--symlinks` option to `zip` command.  It preserves symbolic link in an archive.

- Before

<img width="537" alt="2016-03-23 14 48 48" src="https://cloud.githubusercontent.com/assets/823277/13976868/2b62330a-f107-11e5-8512-0235f0a2ece1.png">

- After

<img width="533" alt="2016-03-23 14 52 07" src="https://cloud.githubusercontent.com/assets/823277/13976871/32ebfd4a-f107-11e5-8918-a20283da0fae.png">

Now darwin package gets 2x smaller :smile: