### PR TITLE
Video fix 

### DIFF
--- a/src/media-popup.js
+++ b/src/media-popup.js
@@ -33,8 +33,8 @@ function resizeMedia(media) {
     }
   }
   if (this.width > 0 ) {
-    media.width = mediaWidth;
-    media.height = mediaHeight;
+    this.width = mediaWidth;
+    this.height = mediaHeight;
   } else {
     media.videoWidth = mediaWidth;
     media.videoHeight = mediaHeight;

--- a/src/media-popup.js
+++ b/src/media-popup.js
@@ -33,11 +33,11 @@ function resizeMedia(media) {
     }
   }
   if (this.width > 0 ) {
-    this.width = mediaWidth;
-    this.height = mediaHeight;
+    media.width = mediaWidth;
+    media.height = mediaHeight;
   } else {
-    this.videoWidth = mediaWidth;
-    this.videoHeight = mediaHeight;
+    media.videoWidth = mediaWidth;
+    media.videoHeight = mediaHeight;
   }
   ipcRenderer.send('imageDimensions', Math.round(mediaWidth), Math.round(mediaHeight));
 }


### PR DESCRIPTION
Alright so I figured out a way to write to videoWidth and videoHeight
for some reason you can write to media.videoWidth but not this.videoWidth.. however if used on img width and height too, sizing doesn't work correctly. I'm wondering whether that could be a bug in electron?