### PR TITLE
Added hls support for media window

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-redux": "^4.4.0",
     "redux": "^3.3.1",
     "redux-thunk": "^2.0.1",
-    "twitter": "^1.2.5"
+    "twitter": "^1.2.5",
+    "hls.js": "^0.6.6"
   },
   "devDependencies": {
     "babel-plugin-syntax-trailing-function-commas": "^6.5.0",

--- a/src/containers/tweet-container.js
+++ b/src/containers/tweet-container.js
@@ -41,10 +41,7 @@ export default class TweetContainer extends BaseContainer {
       if (win != null) {
         const screenWidth  = Math.round((screen.width/2) - (width/2));
         const screenHeight = Math.round((screen.height/3) - (height/3));
-        let options = { x: screenWidth, y: screenHeight, width: width, height: height };
-        if (process.platform === 'darwin') {
-          Object.assign(options, { height: height+20 });
-        }
+        let options = { x: screenWidth, y: screenHeight, width: width, height: height+20 };
         win.setBounds(options, true);
       }
     });

--- a/src/containers/tweet-container.js
+++ b/src/containers/tweet-container.js
@@ -3,6 +3,7 @@ import Actions              from '../actions';
 import BaseContainer        from '../containers/base-container';
 import Tweet                from '../components/tweet';
 import Retweet              from '../components/retweet';
+import { remote } from 'electron';
 
 export default class TweetContainer extends BaseContainer {
   shouldComponentUpdate(nextProps, nextState) {
@@ -17,18 +18,15 @@ export default class TweetContainer extends BaseContainer {
 
   // FIXME: Some parts of this should be moved to a better place.
   openMediaInWindow(media) {
-    // FIXME: Use import
-    const { BrowserWindow } = require('electron').remote;
-    const ipcMain           = require('electron').remote.ipcMain;
+    const BrowserWindow = remote.BrowserWindow;
+    const ipcMain = remote.ipcMain;
 
     let options = { resizable: false, width: 100, height: 100 };
     if (process.platform === 'darwin'){
       Object.assign(options, { titleBarStyle: 'hidden' });
     }
     let win = new BrowserWindow(options);
-
     win.loadURL(`file://${__dirname}../../media-popup.html`);
-
     win.webContents.on('did-finish-load', () => {
       let mediaUrl  = media.media_url;
       let mediaType = '';

--- a/src/containers/tweet-container.js
+++ b/src/containers/tweet-container.js
@@ -37,7 +37,7 @@ export default class TweetContainer extends BaseContainer {
       win.webContents.send('load-media', mediaUrl, mediaType);
     });
 
-    ipcMain.on('imageDimensions', (event, width, height) => {
+    ipcMain.once('imageDimensions', (event, width, height) => {
       if (win != null) {
         const screenWidth  = Math.round((screen.width/2) - (width/2));
         const screenHeight = Math.round((screen.height/3) - (height/3));

--- a/src/containers/tweet-container.js
+++ b/src/containers/tweet-container.js
@@ -3,7 +3,7 @@ import Actions              from '../actions';
 import BaseContainer        from '../containers/base-container';
 import Tweet                from '../components/tweet';
 import Retweet              from '../components/retweet';
-import { remote } from 'electron';
+import { remote }           from 'electron';
 
 export default class TweetContainer extends BaseContainer {
   shouldComponentUpdate(nextProps, nextState) {

--- a/src/media-popup.js
+++ b/src/media-popup.js
@@ -1,5 +1,6 @@
 // FIXME: Refactor later
-import { ipcRenderer } from 'electron';
+import { ipcRenderer }        from 'electron';
+
 var hls = require('hls.js');
 var img = document.getElementById('loadedImage');
 var video = document.getElementById('loadedVideo');

--- a/src/media-popup.js
+++ b/src/media-popup.js
@@ -1,5 +1,5 @@
 // FIXME: Refactor later
-import { ipcRenderer }        from 'electron';
+import { ipcRenderer } from 'electron';
 
 var hls = require('hls.js');
 var img = document.getElementById('loadedImage');
@@ -11,8 +11,8 @@ mediaHeight = 0,
 maxWidth = 800,
 maxHeight = 600;
 
-if (process.platform !== 'darwin'){
-  body.style = "padding-top: 0px;"
+if (process.platform !== 'darwin') {
+  body.style = "padding-top: 0px;";
 }
 
 function resizeMedia(media) {
@@ -20,12 +20,12 @@ function resizeMedia(media) {
     mediaWidth = this.width;
     mediaHeight = this.height;
   } else {
-    if (video.title === "HLS media"){
+    if (video.title === "HLS media") {
       mediaWidth = this.videoWidth * 4;
       mediaHeight = this.videoHeight * 4;
     } else {
-      mediaWidth = this.videoWidth
-      mediaHeight = this.videoHeight
+      mediaWidth = this.videoWidth;
+      mediaHeight = this.videoHeight;
     }
   }
   // Scale media proportionally if larger than maxWidth and maxHeight
@@ -57,14 +57,14 @@ function resizeMedia(media) {
 ipcRenderer.once('load-media', (event, mediaUrl, mediaType) => {
   if (mediaType !== "video/mp4" && mediaType !== "application/x-mpegURL"){
     img.src = mediaUrl;
-    img.onload = resizeMedia.bind(img)
-  } else if (mediaType === "application/x-mpegURL"){
+    img.onload = resizeMedia.bind(img);
+  } else if (mediaType === "application/x-mpegURL") {
     hlsMedia.loadSource(mediaUrl);
     hlsMedia.attachMedia(video);
     video.onloadedmetadata = resizeMedia.bind(hlsMedia.media);
-    video.title = "HLS media"
+    video.title = "HLS media";
   } else {
-    video.src = mediaUrl
+    video.src = mediaUrl;
     video.onloadedmetadata = resizeMedia.bind(video);
     video.preload = "auto";
     video.loop = true;
@@ -72,4 +72,3 @@ ipcRenderer.once('load-media', (event, mediaUrl, mediaType) => {
     video.playbackRate = 1;
   }
 });
-

--- a/src/media-popup.js
+++ b/src/media-popup.js
@@ -14,7 +14,7 @@ function resizeMedia(media) {
     mediaWidth = this.width;
     mediaHeight = this.height;
   } else {
-    if (video.title === "application/x-mpegURL"){
+    if (video.title === "HLS media"){
       mediaWidth = this.videoWidth * 4;
       mediaHeight = this.videoHeight * 4;
     } else {
@@ -52,16 +52,14 @@ ipcRenderer.on('load-media', (event, mediaUrl, mediaType) => {
   if (mediaType !== "video/mp4" && mediaType !== "application/x-mpegURL"){
     img.src = mediaUrl;
     img.onload = resizeMedia.bind(img)
+  } else if (mediaType === "application/x-mpegURL"){
+    hlsMedia.loadSource(mediaUrl);
+    hlsMedia.attachMedia(video);
+    video.onloadedmetadata = resizeMedia.bind(hlsMedia.media);
+    video.title = "HLS media"
   } else {
-    if (mediaType === "application/x-mpegURL"){
-      hlsMedia.loadSource(mediaUrl);
-      hlsMedia.attachMedia(video);
-      video.onloadedmetadata = resizeMedia.bind(hlsMedia.media);
-      video.title = "application/x-mpegURL"
-    } else {
-      video.src = mediaUrl
-      video.onloadedmetadata = resizeMedia.bind(video);
-    }
+    video.src = mediaUrl
+    video.onloadedmetadata = resizeMedia.bind(video);
     video.preload = "auto";
     video.loop = true;
     video.autoplay = true;

--- a/src/media-popup.js
+++ b/src/media-popup.js
@@ -4,11 +4,16 @@ import { ipcRenderer }        from 'electron';
 var hls = require('hls.js');
 var img = document.getElementById('loadedImage');
 var video = document.getElementById('loadedVideo');
+var body = document.getElementsByTagName("body")[0];
 var hlsMedia = new hls();
 var mediaWidth = 0,
 mediaHeight = 0,
 maxWidth = 800,
 maxHeight = 600;
+
+if (process.platform !== 'darwin'){
+  body.style = "padding-top: 0px;"
+}
 
 function resizeMedia(media) {
   if (media.path[0].id === img.id) {

--- a/src/media-popup.js
+++ b/src/media-popup.js
@@ -1,5 +1,5 @@
 // FIXME: Refactor later
-var ipcRenderer = require('electron').ipcRenderer;
+import { ipcRenderer } from 'electron';
 var hls = require('hls.js');
 var img = document.getElementById('loadedImage');
 var video = document.getElementById('loadedVideo');
@@ -48,7 +48,7 @@ function resizeMedia(media) {
   ipcRenderer.send('imageDimensions', Math.round(mediaWidth), Math.round(mediaHeight));
 }
 
-ipcRenderer.on('load-media', (event, mediaUrl, mediaType) => {
+ipcRenderer.once('load-media', (event, mediaUrl, mediaType) => {
   if (mediaType !== "video/mp4" && mediaType !== "application/x-mpegURL"){
     img.src = mediaUrl;
     img.onload = resizeMedia.bind(img)
@@ -66,3 +66,4 @@ ipcRenderer.on('load-media', (event, mediaUrl, mediaType) => {
     video.playbackRate = 1;
   }
 });
+

--- a/src/media-popup.scss
+++ b/src/media-popup.scss
@@ -1,13 +1,15 @@
 body {
   margin: 0px;
-  margin-top: 20px;
+  padding-top: 20px;
   overflow-y: hidden;
   background-color: #e5f2f7;
+  -webkit-app-region: drag;
 }
 
 .mediaWrapper {
   width: 100%;
   height: 100%;
+  -webkit-app-region: no-drag;
 }
 
 video {


### PR DESCRIPTION
Added hls.js dependency to package and hls support for window.
Scaling for hls is not tested thoroughly because i only had one tweet with such content. Also for some reason I wasn't able to get the actual video size of the video container for the new format but a downscaled value instead, which means that I'm multiplying manually. Whether this works for all cases, I don't know, so if you experience weird sizing with such content, that might be the issue.