### PR TITLE
Media popup fixes

### DIFF
--- a/src/media-popup.js
+++ b/src/media-popup.js
@@ -63,9 +63,9 @@ ipcRenderer.once('load-media', (event, mediaUrl, mediaType) => {
       mediaUrl =  mediaUrl.replace(/\.[^\.]+$/, '.m3u8');
     }
     hlsMedia.attachMedia(video);
-    hlsMedia.on(hls.Events.MEDIA_ATTACHED, function()  {
+    hlsMedia.on(hls.Events.MEDIA_ATTACHED, () => {
       hlsMedia.loadSource(mediaUrl);
-      hlsMedia.on(hls.Events.MANIFEST_PARSED, function() {
+      hlsMedia.on(hls.Events.MANIFEST_PARSED, () => {
         video.title = "HLS media";
         video.onloadedmetadata = resizeMedia.bind(hlsMedia.media);
         video.loop = true;

--- a/src/media-popup.js
+++ b/src/media-popup.js
@@ -55,14 +55,23 @@ function resizeMedia(media) {
 }
 
 ipcRenderer.once('load-media', (event, mediaUrl, mediaType) => {
-  if (mediaType !== "video/mp4" && mediaType !== "application/x-mpegURL"){
+  if (mediaType !== "video/mp4" && mediaType !== "application/x-mpegURL" && mediaType !== "application/dash+xml"){
     img.src = mediaUrl;
     img.onload = resizeMedia.bind(img);
-  } else if (mediaType === "application/x-mpegURL") {
-    hlsMedia.loadSource(mediaUrl);
+  } else if (mediaType === "application/x-mpegURL" || mediaType === "application/dash+xml") {
+    if (mediaType === "application/dash+xml") {
+      mediaUrl =  mediaUrl.replace(/\.[^\.]+$/, '.m3u8');
+    }
     hlsMedia.attachMedia(video);
-    video.onloadedmetadata = resizeMedia.bind(hlsMedia.media);
-    video.title = "HLS media";
+    hlsMedia.on(hls.Events.MEDIA_ATTACHED, function()  {
+      hlsMedia.loadSource(mediaUrl);
+      hlsMedia.on(hls.Events.MANIFEST_PARSED, function() {
+        video.title = "HLS media";
+        video.onloadedmetadata = resizeMedia.bind(hlsMedia.media);
+        video.loop = true;
+        video.autoplay = true;
+      });
+    });
   } else {
     video.src = mediaUrl;
     video.onloadedmetadata = resizeMedia.bind(video);


### PR DESCRIPTION
Twitters in addition to mp4 and hls m3u8, had a third video container I didn't know about, mpd, so that's been added now. I also noticed that the video.autoplay would never be played if the container was hls, so that's been fixed too.

