### PR TITLE
Handle authentication challenges

### DIFF
--- a/src/utils/authentication.js
+++ b/src/utils/authentication.js
@@ -124,6 +124,8 @@ export default class Authentication {
           });
         } else if (url.match(/\/account\/login_verification/)) {
           // noop (start of 2FA session)
+        } else if (url.match(/\/account\/login_challenge/)) {
+          // noop (start of login challenge)
         } else if (url.match(/\/oauth\/authenticate/)) {
           // noop (redirection to successful callback)
         } else {


### PR DESCRIPTION
Sometimes Twitter redirects the user to a challenge page, to verify
his identity. This change allows the redirection to happen, so that the
authentication can continue.