### PR TITLE
Minor AUR corrections in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ For some platforms, you can use a package manager to install Nocturn.
   - You can use [homebrew-cask](https://github.com/caskroom/homebrew-cask).
   - `brew install --cask nocturn`
 - Arch Linux
-  - [Arch user repository](https://aur.archlinux.org/packages/nocturn/) is available.
-  - `yaourt -S nocturn`
+  - [Arch User Repository](https://aur.archlinux.org/packages/nocturn/) is available (via AUR helper like `yay`).
+  - `yay -S nocturn`
 
 ## Usage
 


### PR DESCRIPTION
1.  `yaourt` should no longer be used as a currently maintained AUR helper - one that is should be mentioned/recommended, such as `yay`.
2.  `nocturn` in the AUR has been orphaned since version 1.6.6-1 or January 22, 2019.  I don't know if it's better to leave this in here or to outright remove it.  I'll err on the side of caution with the former and will allow maintainers to decide for themselves.