### PR TITLE
Port Twitter-Client to Updated API Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "redux": "^3.3.1",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^2.0.1",
-    "twitter": "^1.7.1"
+    "twitter-api-v2": "^1.5.2"
   },
   "devDependencies": {
     "babel-plugin-syntax-trailing-function-commas": "^6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,11 +1333,6 @@ deep-diff@0.3.4:
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.4.tgz#aac5c39952236abe5f037a2349060ba01b00ae48"
   integrity sha1-qsXDmVIjar5fA3ojSQYLoBsArkg=
 
-deep-extend@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
-  integrity sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==
-
 defaults@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
@@ -4057,7 +4052,7 @@ replace-ext@0.0.1:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
   integrity sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=
 
-request@*, request@^2.61.0, request@^2.72.0, request@^2.87.0, request@^2.88.0:
+request@*, request@^2.61.0, request@^2.87.0, request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -4708,13 +4703,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-twitter@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/twitter/-/twitter-1.7.1.tgz#0762378f1dc1c050e48f666aca904e24b1a962f4"
-  integrity sha1-B2I3jx3BwFDkj2ZqypBOJLGpYvQ=
-  dependencies:
-    deep-extend "^0.5.0"
-    request "^2.72.0"
+twitter-api-v2@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/twitter-api-v2/-/twitter-api-v2-1.5.2.tgz#2160f650bc0e760662e171ccf30ef3930faf3033"
+  integrity sha512-kUrk9u19X4D3RFc4LH3N0bdqRq0fstM3xXerzhxRmPDjwBSyztBGWTU/McGQlGE+q7ADOpfmkvohV5Q4J3ENQw==
 
 type-fest@^0.13.1:
   version "0.13.1"


### PR DESCRIPTION
Motivations for this change:
  - Previous Twitter library out of date by 4 years
  - Twitter API v2 is in the works
  - New library
    - has no direct dependencies, so little library incompatibility
    - is designed to be fully compatible with v1.1 and v2
    - would future proof your app once v2 fully replaces v1.1

Current issues:
  - authentication still relies on separate node-twitter-api
  - new library makes different oauth assumptions
    - the end user generates tokens and secrets using Twitter's developer
      portal and stores them locally
    - the application serves a callback url instead of Twitter's default
      oauth authentication page, allowing for the current authentication
      to work properly
    - if using the default Twitter oauth authentication, the user will
      either be expected to authenticate using a PIN number on the screen
      or all required fields will be handled externally by the app dev

As it stands, the current authentication isn't currently broken, but
once v2 replaces v1.1, it will need to be redone for Nocturn to stay
functional.