### PR TITLE
Lock Node version to 10-LTS + add as devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "gulp-babel": "^6.1.2",
     "gulp-bower": "^0.0.10",
     "gulp-sass": "^2.2.0",
+    "node": "^10.24.1",
     "shelljs": "^0.8.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3305,6 +3305,11 @@ natives@^1.1.3:
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
   integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
+node-bin-setup@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/node-bin-setup/-/node-bin-setup-1.0.6.tgz#4b5c9bb937ece702d7069b36ca78af4684677528"
+  integrity sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -3383,6 +3388,13 @@ node-twitter-api@^1.8.0:
   dependencies:
     oauth ">=0.8.4"
     request "*"
+
+node@^10.24.1:
+  version "10.24.1"
+  resolved "https://registry.yarnpkg.com/node/-/node-10.24.1.tgz#878b51e716097d996352395f4988ec6b4bb40ab1"
+  integrity sha512-3VQ/FYdesUorecUrJAB2ZxeE9E/3Lm1/g0A5Y3jdnDgu/nK9G7pFBgDUlrLkb9FKWPd4pa3ieOAjvlwLSa4F1w==
+  dependencies:
+    node-bin-setup "^1.0.0"
 
 "nopt@2 || 3":
   version "3.0.6"


### PR DESCRIPTION
Fixes:
  - Gentoo & Arch Linux failure to build node-gyp version required
    to install and use current node-sass version due to python2
    support being mostly dropped

Node 12+ may work for other operating systems but locking to a
specific node version until old libraries are either updated or
fully replaced can help keep things building smoothly if others
start contributing more