### PR TITLE
Delete + Retweet typo fix

### DIFF
--- a/src/utils/twitter-client.js
+++ b/src/utils/twitter-client.js
@@ -108,7 +108,7 @@ Nocturn prohibits over 20 mentions per minute.`);
   }
 
   retweetStatus(tweetId, callback) {
-    this.client.v1.post(`statuses/retweet/${tweetId}`, this.extendParams({ id: tweetId }))
+    this.client.v1.post(`statuses/retweet/${tweetId}.json`, this.extendParams({ id: tweetId }))
       .then(data => { 
         callback(data);
         if (data.error) {
@@ -119,7 +119,7 @@ Nocturn prohibits over 20 mentions per minute.`);
   }
 
   deleteStatus(tweetId, callback) {
-    this.client.v1.post(`statuses/destroy/${tweetId}`, this.extendParams({ id: tweetId }))
+    this.client.v1.post(`statuses/destroy/${tweetId}.json`, this.extendParams({ id: tweetId }))
       .then(data => { 
         callback(data);
         if (data.error) {


### PR DESCRIPTION
Both retweeting and deleting weren't functioning properly due to a small typo.

https://github.com/PLhery/node-twitter-api-v2/blob/6666305d8e75c1b5fec8db92e0655584e018d2d1/src/v1/client.v1.write.ts#L104